### PR TITLE
Add Pulse for coalescing on-demand work

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The library supports several common concurrency patterns out of the box:
 - **Fork/Join** - Parallel task execution with result aggregation  
 - **Throttling** - Rate limiting with `Consume` and custom concurrency
 - **Repeating** - Periodic execution with `Repeat`
+- **Pulsing** - Coalescing on-demand execution with `Pulse`
 - **Task Chaining** - Sequential execution with `After` for processing pipelines
 
 
@@ -194,15 +195,29 @@ Repeating tasks enable periodic execution of operations at regular intervals. Th
 
 ```go
 // Heartbeat every 30 seconds
-heartbeat := async.Repeat(context.Background(), 30*time.Second, 
-    func(ctx context.Context) (string, error) {
-        // Send heartbeat (placeholder function)
-        return "heartbeat sent", nil
+heartbeat := async.Repeat(context.Background(), 30*time.Second,
+    func(ctx context.Context) {
+        // Send heartbeat
     })
 
 // Stop after 5 minutes
 time.Sleep(5 * time.Minute)
 heartbeat.Cancel()
+```
+
+## Pulsed Tasks
+
+Pulsed tasks run when signaled, coalescing overlapping wakes into one pending run. An optional interval also wakes the worker for periodic repair.
+
+```go
+reconcile := async.Pulse(context.Background(), 30*time.Second,
+    func(ctx context.Context) {
+        // Reconcile state; handle errors inside
+    })
+
+reconcile.Pulse() // wake now (coalescing)
+reconcile.Cancel()
+_ = reconcile.Wait()
 ```
 
 ## Task Chaining

--- a/bench/main.go
+++ b/bench/main.go
@@ -89,20 +89,6 @@ func main() {
 			return taskCount
 		})
 
-		b.RunN("pulse-signal", func(int) int {
-			block := make(chan struct{})
-			p := async.Pulse(ctx, 0, func(context.Context) {
-				<-block
-			})
-			p.Pulse() // park worker so later pulses only hit the coalesce path
-			for range taskCount {
-				p.Pulse()
-			}
-			close(block)
-			p.Cancel()
-			_ = p.Wait()
-			return taskCount
-		})
 	}, bench.WithSamples(25), bench.WithDuration(20*time.Millisecond), bench.WithThreshold(20))
 }
 

--- a/bench/main.go
+++ b/bench/main.go
@@ -23,7 +23,7 @@ func main() {
 	bench.Run(func(b *bench.B) {
 		b.RunN("consume", func(int) int {
 			tasks := make(chan async.Task[any], taskCount)
-			for i := 0; i < taskCount; i++ {
+			for range taskCount {
 				tasks <- async.NewTask(noop)
 			}
 			close(tasks)
@@ -32,7 +32,7 @@ func main() {
 		})
 
 		b.RunN("invoke", func(int) int {
-			for i := 0; i < taskCount; i++ {
+			for range taskCount {
 				_, _ = async.Invoke(ctx, noop).Outcome()
 			}
 			return taskCount
@@ -40,7 +40,7 @@ func main() {
 
 		b.RunN("all", func(int) int {
 			tasks := make([]async.Task[any], 0, taskCount)
-			for i := 0; i < taskCount; i++ {
+			for range taskCount {
 				tasks = append(tasks, async.NewTask(noop))
 			}
 			_ = async.InvokeAll(ctx, concurrency, tasks).Wait()
@@ -48,7 +48,7 @@ func main() {
 		})
 
 		b.RunN("done", func(int) int {
-			for i := 0; i < taskCount; i++ {
+			for range taskCount {
 				task := async.NewTask(noop)
 				done := async.Done(task)
 				task.Run(ctx)
@@ -58,7 +58,7 @@ func main() {
 		})
 
 		b.RunN("completed", func(int) int {
-			for i := 0; i < taskCount; i++ {
+			for range taskCount {
 				_, _ = async.Completed[any](nil).Outcome()
 			}
 			return taskCount
@@ -66,9 +66,41 @@ func main() {
 
 		err := errors.New("test error")
 		b.RunN("fail", func(int) int {
-			for i := 0; i < taskCount; i++ {
+			for range taskCount {
 				_, _ = async.Failed[any](err).Outcome()
 			}
+			return taskCount
+		})
+
+		b.RunN("pulse", func(int) int {
+			ran := make(chan struct{}, 1)
+			p := async.Pulse(ctx, 0, func(context.Context) {
+				select {
+				case ran <- struct{}{}:
+				default:
+				}
+			})
+			for range taskCount {
+				p.Pulse()
+				<-ran
+			}
+			p.Cancel()
+			_ = p.Wait()
+			return taskCount
+		})
+
+		b.RunN("pulse-signal", func(int) int {
+			block := make(chan struct{})
+			p := async.Pulse(ctx, 0, func(context.Context) {
+				<-block
+			})
+			p.Pulse() // park worker so later pulses only hit the coalesce path
+			for range taskCount {
+				p.Pulse()
+			}
+			close(block)
+			p.Cancel()
+			_ = p.Wait()
 			return taskCount
 		})
 	}, bench.WithSamples(25), bench.WithDuration(20*time.Millisecond), bench.WithThreshold(20))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kelindar/async
 
-go 1.23
+go 1.24
 
 require github.com/stretchr/testify v1.10.0
 

--- a/pulse.go
+++ b/pulse.go
@@ -1,0 +1,100 @@
+// Copyright 2019 Grabtaxi Holdings PTE LTE (GRAB), All rights reserved.
+// Copyright (c) 2021-2026 Roman Atachiants
+// Use of this source code is governed by an MIT-style license that can be found in the LICENSE file
+
+package async
+
+import (
+	"context"
+	"time"
+)
+
+// Pulser is a long-running awaiter that runs work when pulsed.
+type Pulser interface {
+	Awaiter
+	Pulse()
+}
+
+type pulser struct {
+	task    Awaiter
+	trigger chan struct{}
+	cancel  context.CancelFunc
+}
+
+// Pulse wakes the worker. Concurrent pulses while a run is pending or in
+// progress coalesce to a single pending run.
+func (p *pulser) Pulse() {
+	select {
+	case p.trigger <- struct{}{}:
+	default:
+	}
+}
+
+// Wait waits for the pulser to stop.
+func (p *pulser) Wait() error {
+	return p.task.Wait()
+}
+
+// Cancel stops the pulser by cancelling its context.
+func (p *pulser) Cancel() {
+	p.cancel()
+}
+
+// State returns the underlying task state.
+func (p *pulser) State() State {
+	return p.task.State()
+}
+
+// Done returns a channel that is closed when the pulser stops.
+func (p *pulser) Done() <-chan struct{} {
+	return Done(p.task)
+}
+
+// Pulse runs action whenever Pulse() is called. Overlapping pulses coalesce to
+// one pending run. If interval is greater than zero, the action is also woken
+// on that ticker. Handle errors inside the action (or cancel the context).
+// The action is never invoked concurrently.
+func Pulse(ctx context.Context, interval time.Duration, action func(context.Context)) Pulser {
+	ctx, cancel := context.WithCancel(ctx)
+	trigger := make(chan struct{}, 1)
+
+	task := Invoke(ctx, func(taskCtx context.Context) (struct{}, error) {
+		if interval > 0 {
+			return pulseTicker(taskCtx, interval, trigger, action)
+		}
+		return pulseWait(taskCtx, trigger, action)
+	})
+
+	return &pulser{
+		task:    task,
+		trigger: trigger,
+		cancel:  cancel,
+	}
+}
+
+func pulseWait(ctx context.Context, trigger <-chan struct{}, action func(context.Context)) (struct{}, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return struct{}{}, nil
+		case <-trigger:
+			action(ctx)
+		}
+	}
+}
+
+func pulseTicker(ctx context.Context, interval time.Duration, trigger <-chan struct{}, action func(context.Context)) (struct{}, error) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return struct{}{}, nil
+		case <-trigger:
+			action(ctx)
+		case <-ticker.C:
+			action(ctx)
+		}
+	}
+}

--- a/pulse_test.go
+++ b/pulse_test.go
@@ -324,6 +324,9 @@ func TestPulse(t *testing.T) {
 
 	t.Run("done closes on cancel", func(t *testing.T) {
 		p := Pulse(context.Background(), 0, func(context.Context) {})
+		require.Eventually(t, func() bool {
+			return p.State() == IsRunning
+		}, time.Second, time.Millisecond)
 		done := Done(p)
 		select {
 		case <-done:
@@ -337,6 +340,7 @@ func TestPulse(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatal("done did not close after cancel")
 		}
+		assert.True(t, p.State() == IsCompleted || p.State() == IsCancelled)
 	})
 }
 

--- a/pulse_test.go
+++ b/pulse_test.go
@@ -1,0 +1,361 @@
+// Copyright 2019 Grabtaxi Holdings PTE LTE (GRAB), All rights reserved.
+// Copyright (c) 2021-2026 Roman Atachiants
+// Use of this source code is governed by an MIT-style license that can be found in the LICENSE file
+
+package async
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPulse(t *testing.T) {
+	t.Run("runs on pulse", func(t *testing.T) {
+		ctx := t.Context()
+
+		ran := make(chan struct{}, 1)
+		p := Pulse(ctx, 0, func(context.Context) {
+			ran <- struct{}{}
+		})
+		defer p.Cancel()
+
+		select {
+		case <-ran:
+			t.Fatal("action ran before pulse")
+		case <-time.After(20 * time.Millisecond):
+		}
+
+		p.Pulse()
+		select {
+		case <-ran:
+		case <-time.After(time.Second):
+			t.Fatal("action did not run after pulse")
+		}
+	})
+
+	t.Run("coalesces overlapping pulses", func(t *testing.T) {
+		ctx := t.Context()
+
+		var runs atomic.Int64
+		started := make(chan struct{}, 2)
+		block := make(chan struct{})
+
+		p := Pulse(ctx, 0, func(context.Context) {
+			runs.Add(1)
+			started <- struct{}{}
+			<-block
+		})
+		defer p.Cancel()
+
+		p.Pulse()
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("first run did not start")
+		}
+
+		for range 100 {
+			p.Pulse()
+		}
+		close(block)
+
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("coalesced run did not start")
+		}
+
+		time.Sleep(20 * time.Millisecond)
+		p.Cancel()
+		require.NoError(t, waitDone(p, time.Second))
+
+		assert.EqualValues(t, 2, runs.Load(), "100 pulses during one run should coalesce to one pending run")
+	})
+
+	t.Run("serializes action", func(t *testing.T) {
+		ctx := t.Context()
+
+		var concurrent atomic.Int32
+		var maxConcurrent atomic.Int32
+		started := make(chan struct{}, 64)
+
+		p := Pulse(ctx, 0, func(context.Context) {
+			cur := concurrent.Add(1)
+			for {
+				prev := maxConcurrent.Load()
+				if cur <= prev || maxConcurrent.CompareAndSwap(prev, cur) {
+					break
+				}
+			}
+			time.Sleep(5 * time.Millisecond)
+			concurrent.Add(-1)
+			started <- struct{}{}
+		})
+		defer p.Cancel()
+
+		for range 20 {
+			p.Pulse()
+		}
+
+		require.Eventually(t, func() bool {
+			return len(started) >= 1
+		}, time.Second, time.Millisecond)
+
+		require.Eventually(t, func() bool {
+			n := len(started)
+			time.Sleep(20 * time.Millisecond)
+			return len(started) == n && concurrent.Load() == 0
+		}, time.Second, 5*time.Millisecond)
+
+		p.Cancel()
+		require.NoError(t, waitDone(p, time.Second))
+		assert.EqualValues(t, 1, maxConcurrent.Load())
+		assert.GreaterOrEqual(t, len(started), 1)
+		assert.LessOrEqual(t, len(started), 20)
+	})
+
+	t.Run("interval wakes without pulse", func(t *testing.T) {
+		ctx := t.Context()
+
+		ran := make(chan struct{}, 4)
+		p := Pulse(ctx, 15*time.Millisecond, func(context.Context) {
+			ran <- struct{}{}
+		})
+		defer p.Cancel()
+
+		for i := range 2 {
+			select {
+			case <-ran:
+			case <-time.After(time.Second):
+				t.Fatalf("interval tick %d did not fire", i+1)
+			}
+		}
+	})
+
+	t.Run("interval zero does not tick", func(t *testing.T) {
+		ctx := t.Context()
+
+		var runs atomic.Int64
+		p := Pulse(ctx, 0, func(context.Context) {
+			runs.Add(1)
+		})
+		defer p.Cancel()
+
+		time.Sleep(40 * time.Millisecond)
+		assert.EqualValues(t, 0, runs.Load())
+	})
+
+	t.Run("runs repeatedly on pulse", func(t *testing.T) {
+		ctx := t.Context()
+
+		var calls atomic.Int64
+		p := Pulse(ctx, 0, func(context.Context) {
+			calls.Add(1)
+		})
+		defer p.Cancel()
+
+		p.Pulse()
+		require.Eventually(t, func() bool {
+			return calls.Load() >= 1
+		}, time.Second, time.Millisecond)
+
+		time.Sleep(10 * time.Millisecond)
+		p.Pulse()
+		require.Eventually(t, func() bool {
+			return calls.Load() >= 2
+		}, time.Second, time.Millisecond)
+
+		p.Cancel()
+		assert.True(t, isCancelErr(p.Wait()))
+	})
+
+	t.Run("context cancelled before start", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		called := false
+		p := Pulse(ctx, time.Millisecond, func(context.Context) {
+			called = true
+		})
+
+		err := p.Wait()
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.False(t, called)
+	})
+
+	t.Run("context timeout", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
+		defer cancel()
+
+		var calls atomic.Int64
+		p := Pulse(ctx, 10*time.Millisecond, func(context.Context) {
+			calls.Add(1)
+		})
+
+		err := p.Wait()
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.GreaterOrEqual(t, calls.Load(), int64(1))
+	})
+
+	t.Run("cancel stops worker", func(t *testing.T) {
+		var calls atomic.Int64
+		p := Pulse(context.Background(), 5*time.Millisecond, func(context.Context) {
+			calls.Add(1)
+		})
+
+		require.Eventually(t, func() bool {
+			return calls.Load() >= 1
+		}, time.Second, time.Millisecond)
+
+		p.Cancel()
+		require.NoError(t, waitDone(p, time.Second))
+		after := calls.Load()
+		time.Sleep(30 * time.Millisecond)
+		assert.Equal(t, after, calls.Load(), "calls should not increase after cancel")
+	})
+
+	t.Run("pulse after cancel does not panic", func(t *testing.T) {
+		p := Pulse(context.Background(), 0, func(context.Context) {})
+		p.Cancel()
+		require.NoError(t, waitDone(p, time.Second))
+		assert.NotPanics(t, func() {
+			for range 10 {
+				p.Pulse()
+			}
+		})
+	})
+
+	t.Run("concurrent pulses are race safe", func(t *testing.T) {
+		ctx := t.Context()
+
+		var runs atomic.Int64
+		var inFlight atomic.Int32
+		p := Pulse(ctx, 0, func(context.Context) {
+			if inFlight.Add(1) != 1 {
+				t.Error("overlapping action execution")
+			}
+			defer inFlight.Add(-1)
+			time.Sleep(time.Millisecond)
+			runs.Add(1)
+		})
+		defer p.Cancel()
+
+		var wg sync.WaitGroup
+		for range 32 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for range 50 {
+					p.Pulse()
+				}
+			}()
+		}
+		wg.Wait()
+
+		require.Eventually(t, func() bool {
+			return runs.Load() >= 1
+		}, time.Second, time.Millisecond)
+
+		require.Eventually(t, func() bool {
+			before := runs.Load()
+			time.Sleep(20 * time.Millisecond)
+			return runs.Load() == before && inFlight.Load() == 0
+		}, time.Second, 5*time.Millisecond)
+
+		p.Cancel()
+		require.NoError(t, waitDone(p, time.Second))
+		assert.GreaterOrEqual(t, runs.Load(), int64(1))
+		assert.LessOrEqual(t, runs.Load(), int64(32*50))
+	})
+
+	t.Run("interval and pulse both wake", func(t *testing.T) {
+		ctx := t.Context()
+
+		ran := make(chan string, 8)
+		p := Pulse(ctx, 30*time.Millisecond, func(context.Context) {
+			ran <- "tick"
+		})
+		defer p.Cancel()
+
+		p.Pulse()
+		select {
+		case <-ran:
+		case <-time.After(time.Second):
+			t.Fatal("manual pulse did not run")
+		}
+
+		select {
+		case <-ran:
+		case <-time.After(time.Second):
+			t.Fatal("interval did not run")
+		}
+	})
+
+	t.Run("passes context to action", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		saw := make(chan context.Context, 1)
+		p := Pulse(ctx, 0, func(actx context.Context) {
+			saw <- actx
+		})
+		defer p.Cancel()
+
+		p.Pulse()
+		select {
+		case actx := <-saw:
+			assert.NotNil(t, actx)
+			cancel()
+			<-Done(p)
+			assert.Error(t, actx.Err())
+		case <-time.After(time.Second):
+			t.Fatal("action did not run")
+		}
+	})
+
+	t.Run("done closes on cancel", func(t *testing.T) {
+		p := Pulse(context.Background(), 0, func(context.Context) {})
+		done := Done(p)
+		select {
+		case <-done:
+			t.Fatal("done closed before cancel")
+		default:
+		}
+
+		p.Cancel()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("done did not close after cancel")
+		}
+	})
+}
+
+func waitDone(a Awaiter, timeout time.Duration) error {
+	done := make(chan error, 1)
+	go func() {
+		done <- a.Wait()
+	}()
+	select {
+	case err := <-done:
+		if isCancelErr(err) {
+			return nil
+		}
+		return err
+	case <-time.After(timeout):
+		return errors.New("wait timed out")
+	}
+}
+
+func isCancelErr(err error) bool {
+	return err == nil || errors.Is(err, context.Canceled)
+}

--- a/repeat.go
+++ b/repeat.go
@@ -1,5 +1,5 @@
 // Copyright 2019 Grabtaxi Holdings PTE LTE (GRAB), All rights reserved.
-// Copyright (c) 2021-2025 Roman Atachiants
+// Copyright (c) 2021-2026 Roman Atachiants
 // Use of this source code is governed by an MIT-style license that can be found in the LICENSE file
 
 package async
@@ -10,18 +10,18 @@ import (
 )
 
 // Repeat performs an action asynchronously on a predetermined interval.
-func Repeat[T any](ctx context.Context, interval time.Duration, action Work[T]) Awaiter {
-	return Invoke(ctx, func(taskCtx context.Context) (T, error) {
+// Handle errors inside the action (or cancel the context).
+func Repeat(ctx context.Context, interval time.Duration, action func(context.Context)) Awaiter {
+	return Invoke(ctx, func(taskCtx context.Context) (struct{}, error) {
 		timer := time.NewTicker(interval)
 		for {
 			select {
 			case <-taskCtx.Done():
 				timer.Stop()
-				var zero T
-				return zero, nil
+				return struct{}{}, nil
 
 			case <-timer.C:
-				_, _ = action(taskCtx)
+				action(taskCtx)
 			}
 		}
 	})

--- a/repeat_test.go
+++ b/repeat_test.go
@@ -1,13 +1,11 @@
 // Copyright 2019 Grabtaxi Holdings PTE LTE (GRAB), All rights reserved.
-// Copyright (c) 2021-2025 Roman Atachiants
+// Copyright (c) 2021-2026 Roman Atachiants
 // Use of this source code is governed by an MIT-style license that can be found in the LICENSE file
 
 package async
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -19,9 +17,8 @@ func TestRepeat(t *testing.T) {
 	t.Run("fires repeatedly", func(t *testing.T) {
 		assert.NotPanics(t, func() {
 			out := make(chan bool, 1)
-			task := Repeat(context.TODO(), time.Nanosecond*10, func(context.Context) (any, error) {
+			task := Repeat(context.TODO(), time.Nanosecond*10, func(context.Context) {
 				out <- true
-				return nil, nil
 			})
 
 			<-out
@@ -31,36 +28,16 @@ func TestRepeat(t *testing.T) {
 		})
 	})
 
-	t.Run("typed", func(t *testing.T) {
+	t.Run("keeps calling", func(t *testing.T) {
 		var counter atomic.Int64
-		task := Repeat(context.TODO(), time.Millisecond*100, func(ctx context.Context) (string, error) {
-			count := counter.Add(1)
-			return fmt.Sprintf("tick-%d", count), nil
-		})
-
-		time.Sleep(time.Millisecond * 150)
-		task.Cancel()
-
-		intTask := Repeat(context.TODO(), time.Millisecond*50, func(ctx context.Context) (int, error) {
-			return int(time.Now().UnixNano() % 1000), nil
-		})
-
-		time.Sleep(time.Millisecond * 100)
-		intTask.Cancel()
-	})
-
-	t.Run("continues on error", func(t *testing.T) {
-		var errorCount atomic.Int64
-		task := Repeat(context.TODO(), time.Millisecond*10, func(ctx context.Context) (string, error) {
-			errorCount.Add(1)
-			return "", errors.New("test error")
+		task := Repeat(context.TODO(), time.Millisecond*10, func(context.Context) {
+			counter.Add(1)
 		})
 
 		time.Sleep(time.Millisecond * 50)
 		task.Cancel()
 
-		count := errorCount.Load()
-		assert.True(t, count > 1, "Action should have been called multiple times, got %d", count)
+		assert.Greater(t, counter.Load(), int64(1))
 	})
 
 	t.Run("context cancelled", func(t *testing.T) {
@@ -68,9 +45,8 @@ func TestRepeat(t *testing.T) {
 		cancel()
 
 		actionCalled := false
-		task := Repeat(ctx, time.Millisecond*10, func(ctx context.Context) (string, error) {
+		task := Repeat(ctx, time.Millisecond*10, func(context.Context) {
 			actionCalled = true
-			return "should not be called", nil
 		})
 
 		err := task.Wait()
@@ -84,9 +60,8 @@ func TestRepeat(t *testing.T) {
 		defer cancel()
 
 		var actionCount atomic.Int64
-		task := Repeat(ctx, time.Millisecond*10, func(ctx context.Context) (string, error) {
-			count := actionCount.Add(1)
-			return fmt.Sprintf("action-%d", count), nil
+		task := Repeat(ctx, time.Millisecond*10, func(context.Context) {
+			actionCount.Add(1)
 		})
 
 		err := task.Wait()


### PR DESCRIPTION
## Summary
- Add `async.Pulse` for coalescing on-demand (and optional periodic) background work, with zero-alloc wakes after construction
- Breaking: change `Repeat` (and `Pulse`) to take `func(context.Context)` instead of unused `Work[T]`
- Add `pulse` / `pulse-signal` benches; bump module to Go 1.24

## Test plan
- [x] `go test -race ./...`
- [x] `cd bench && go run .`
- [ ] Confirm CI passes


Made with [Cursor](https://cursor.com)